### PR TITLE
Fix run_trial docstring

### DIFF
--- a/psyflow/BlockUnit.py
+++ b/psyflow/BlockUnit.py
@@ -217,9 +217,9 @@ class BlockUnit:
         Parameters
         ----------
         func : Callable
-            Function to run each trial. Must accept (win, kb, settings, condition, **extra_args).
-        extra_args : dict
-            Additional arguments passed to the trial function.
+            Function to run each trial. Must accept ``(win, kb, settings, condition, **kwargs)``.
+        **kwargs : dict
+            Additional keyword arguments forwarded to ``func``.
         """
         self.meta['block_start_time'] = core.getAbsTime()
         self.logging_block_info()


### PR DESCRIPTION
## Summary
- clarify that additional keyword arguments are forwarded via `**kwargs` in `BlockUnit.run_trial`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416c1ab7ec832497a1acf23818ea30