### PR TITLE
Fix probabilistic reversal learning typos

### DIFF
--- a/docs/tutorials/build_blocks.md
+++ b/docs/tutorials/build_blocks.md
@@ -226,7 +226,7 @@ df = pd.DataFrame(all_data)
 df.to_csv(settings.res_file, index=False)
 ```
 
-#### 8.2. Probalistic revesal learning (PRL) task example.
+#### 8.2. Probabilistic reversal learning (PRL) task example.
 
 Note that we defined stim_bank within the block loop, so it is different for each block.
 

--- a/docs/tutorials/build_stimulus.md
+++ b/docs/tutorials/build_stimulus.md
@@ -313,7 +313,7 @@ stim_bank.add_from_dict(stim_config)
 stim_bank.preload_all()
 ```
 
-#### 10.2. Probalistic reversal learning (PRL) task example.
+#### 10.2. Probabilistic reversal learning (PRL) task example.
 
 ```yaml
 stimuli:


### PR DESCRIPTION
## Summary
- fix typos in build_blocks tutorial section title
- fix typos in build_stimulus tutorial section title

## Testing
- `pip install -r requirements.txt`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_68416c1012908324abbd182d27b8fdb6