### PR TITLE
Add CLI usage tutorial

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Start with one of the tutorials below or explore the API reference.
    tutorials/build_stimunit
    tutorials/build_stimulus
    tutorials/send_trigger
+   tutorials/cli_usage
    
 
 .. toctree::

--- a/docs/tutorials/cli_usage.md
+++ b/docs/tutorials/cli_usage.md
@@ -1,0 +1,18 @@
+## 🖥️ CLI Usage and `taps()`
+
+psyflow includes a small command-line tool for creating a new project from the bundled template. From a terminal run:
+
+    psyflow-init [PROJECT_NAME]
+
+With no argument or when `[PROJECT_NAME]` matches the current folder name, the template files are generated in place. Otherwise a new directory of that name is created next to your current path.
+
+The same behavior is available programmatically through `psyflow.utils.taps()` if you prefer calling it from Python:
+
+```python
+from psyflow.utils import taps
+
+# create or populate "MyStudy" using the default template
+taps("MyStudy")
+```
+
+Both approaches use cookiecutter to copy the bundled `cookiecutter-psyflow` template into your project.


### PR DESCRIPTION
## Summary
- document `psyflow-init` command and `taps()` usage
- link new page in docs index

## Testing
- `pip install -r docs/requirements.txt`
- `pip install furo`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_6841700b722083248f26c681e3fab361