### PR TITLE
Update trigger docs

### DIFF
--- a/docs/api/psyflow.rst
+++ b/docs/api/psyflow.rst
@@ -44,14 +44,6 @@ psyflow.StimUnit module
    :undoc-members:
    :show-inheritance:
 
-psyflow.TriggerBank module
---------------------------
-
-.. automodule:: psyflow.TriggerBank
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 psyflow.TriggerSender module
 ----------------------------
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -9,7 +9,6 @@ API Reference
    psyflow/StimUnit
    psyflow/StimBank
    psyflow/SubInfo
-   psyflow/TriggerBank
    psyflow/TriggerSender
    psyflow/TaskSettings
    psyflow/utils

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -29,7 +29,7 @@ A typical psyflow experiment has these core steps:
 1. **Configure** experiment settings (`TaskSettings`)  
 2. **Collect** participant info (`SubInfo`)  
 3. **Build** stimuli (`StimBank`)  
-4. **Define** triggers (`TriggerBank` + `TriggerSender`)  
+4. **Define** triggers (a dictionary of codes + `TriggerSender`)
 5. **Create** a trial (`StimUnit`)  
 6. **Run** the trial and collect data  
 
@@ -94,10 +94,12 @@ Retrieve with:
 
 ### 6. Set Up Triggers
 
-    from psyflow import TriggerBank, TriggerSender
+    import yaml
+    from psyflow import TriggerSender
 
-    tb = TriggerBank()
-    tb.add_from_yaml("triggers.yaml")   # or .add_from_dict(...)
+    with open("triggers.yaml") as f:
+        triggers = yaml.safe_load(f)
+
     sender = TriggerSender(lambda code: port.write(bytes([code])))
 
 
@@ -109,13 +111,13 @@ Retrieve with:
     trial = StimUnit("T1", win, kb, triggersender=sender)
     trial \
       .add_stim(fix, tgt) \
-      .on_start(lambda u: u.send_trigger(tb.get("fix_onset"))) \
+      .on_start(lambda u: u.send_trigger(triggers["fix_onset"])) \
       .capture_response(
          keys=["left","right"],
          duration=1.0,
-         onset_trigger=tb.get("fix_onset"),
-         response_trigger={"left":tb.get("resp_L"), "right":tb.get("resp_R")},
-         timeout_trigger=tb.get("timeout"),
+         onset_trigger=triggers["fix_onset"],
+         response_trigger={"left":triggers["resp_L"], "right":triggers["resp_R"]},
+         timeout_trigger=triggers["timeout"],
          correct_keys=["left"],
          highlight_stim={"left": highlight_left, "right": highlight_right}
       ) \

--- a/docs/tutorials/send_trigger.md
+++ b/docs/tutorials/send_trigger.md
@@ -1,17 +1,8 @@
-# ⏱ Trigger System for EEG/MEG: `TriggerBank` + `TriggerSender`
+# ⏱ Trigger System for EEG/MEG: Trigger Dictionary + `TriggerSender`
 
-This system separates **trigger definition** (`TriggerBank`) from **trigger sending** (`TriggerSender`), allowing you to maintain clean logic, central config, and robust signal dispatch for EEG/MEG experiments.
+Store your event codes in a plain dictionary and let `TriggerSender` handle the dispatch. This keeps your configuration centralized and your send logic simple.
 
 ### 🧵 Summary of Key Methods 
-
-#### `TriggerBank`
-
-| Purpose                  | Method                  |
-|--|--|
-| Add one event-code       | `.add(event, code)`      |
-| Add from dict            | `.add_from_dict(dict)`   |
-| Add from YAML file       | `.add_from_yaml(path)`   |
-| Retrieve code            | `.get(event)`            |
 
 #### `TriggerSender`
 
@@ -23,40 +14,34 @@ This system separates **trigger definition** (`TriggerBank`) from **trigger send
 | Control post-delay         | `post_delay=0.001`       |
 
 
-### 🗂 1. Defining Triggers with `TriggerBank`
+### 🗂 1. Prepare a Trigger Dictionary
 
-TriggerBank maps event labels (e.g., "cue_onset", "response") to integer codes.
+Store event labels (e.g., "cue_onset", "response") as keys in a dictionary with integer codes as values.
 
 #### A. Define manually
 
-    from your_package import TriggerBank
-
-    tb = TriggerBank()
-    tb.add("cue_onset", 32)
-    tb.add("key_press", 33)
-
-#### B. Load from a dictionary
-
-    tb.add_from_dict({
+    triggers = {
         "cue_onset": 32,
-        "key_press": [33]  # also accepts single-item list (YAML-safe)
-    })
+        "key_press": 33,
+    }
 
-#### C. Load from YAML
+#### B. Load from YAML
 
 YAML format:
 
     triggers:
       cue_onset: 32
-      key_press: [33]
+      key_press: 33
 
 Code:
 
-    tb.add_from_yaml("trigger_config.yaml")
+    import yaml
+    with open("trigger_config.yaml") as f:
+        triggers = yaml.safe_load(f)["triggers"]
 
-#### D. Get a code
+#### C. Get a code
 
-    code = tb.get("key_press")  # returns 33 or None
+    code = triggers["key_press"]  # returns 33
 
 
 
@@ -77,7 +62,7 @@ TriggerSender handles the dispatch logic. It wraps your actual send function (e.
 
 #### C. Sending a trigger
 
-    sender.send(tb.get("cue_onset"))
+    sender.send(triggers["cue_onset"])
 
 This prints:
 
@@ -104,7 +89,6 @@ Here we used mock mode for testing and a serial port for real device communicati
 trigger_config = {
     **config.get('triggers', {})
 }
-triggerbank = TriggerBank(trigger_config)
 ser = serial.serial_for_url("loop://", baudrate=115200, timeout=1)
 triggersender = TriggerSender(
     trigger_func=lambda code: ser.write([1, 225, 1, 0, (code)]),
@@ -114,4 +98,4 @@ triggersender = TriggerSender(
 )
 ```
 
-Using `TriggerBank` and `TriggerSender` gives you a clean separation of config and logic, making your experiment easier to debug, replicate, and maintain.
+Using a trigger dictionary with `TriggerSender` keeps configuration and logic separated, making your experiment easier to debug, replicate, and maintain.


### PR DESCRIPTION
## Summary
- document using plain trigger dicts
- adjust tutorials to remove TriggerBank usage
- drop TriggerBank entries from API docs

## Testing
- `pip install -r docs/requirements.txt`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_68416ff231848324b071328afad894bf