### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-publish:
+    if: contains(github.event.head_commit.message, '[publish]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# psyflow
+
+This repository hosts the **psyflow** package.
+
+## Publishing to PyPI
+
+Releases are automated with GitHub Actions. Any push to the `main` branch
+that contains `[publish]` in the commit message will trigger the
+[`publish`](.github/workflows/publish.yml) workflow. The workflow builds
+sdist and wheel via `python -m build` and uploads them to PyPI using the
+`pypa/gh-action-pypi-publish` action. The upload requires a
+`PYPI_API_TOKEN` secret configured in the repository.
+
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish to PyPI
- document the workflow usage in a new README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841704f086883249d9620805aa41b86