### PR TITLE
Improve READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # psyflow
 
-This repository hosts the **psyflow** package.
+**psyflow** is a small framework that helps build modular cognitive and
+behavioural experiments on top of
+[PsychoPy](https://www.psychopy.org/).  It bundles a collection of helper
+classes and utilities so you can focus on experimental logic rather than
+boilerplate.
+
+## Key components
+
+- **BlockUnit** – manage blocks of trials and collect results
+- **StimUnit** – present a single trial and log responses
+- **StimBank** – register and build stimuli from Python functions or YAML
+  definitions
+- **SubInfo** – gather participant information via a simple GUI
+- **TaskSettings** – central configuration object for an experiment
+- **TriggerSender** – send triggers to external devices (e.g. EEG/MEG)
+
+The package also provides a command line tool `psyflow-init` which
+scaffolds a new project using the bundled cookiecutter template.
+
+Comprehensive documentation and tutorials are available on the
+[GitHub&nbsp;Pages site](https://taskbeacon.github.io/psyflow/).
 
 ## Publishing to PyPI
 

--- a/psyflow/templates/cookiecutter-psyflow/{{cookiecutter.project_name}}/README.md
+++ b/psyflow/templates/cookiecutter-psyflow/{{cookiecutter.project_name}}/README.md
@@ -1,0 +1,10 @@
+This project was generated with **psyflow-init**.
+
+## Usage
+
+1. Edit the configuration files under `config/` to define your
+   stimuli, trigger codes and general task settings.
+2. Run `python main.py` to launch the experiment.
+
+For full documentation on psyflow and how to customise this template,
+visit the [GitHub&nbsp;Pages site](https://taskbeacon.github.io/psyflow/).


### PR DESCRIPTION
## Summary
- expand the top level README with an overview of the main modules
- add a short README for the cookiecutter template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9008d2308324bff9d5190d92f2f6