### PR TITLE
Update dependency lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "psychopy",
     "numpy",
     "pandas",
+    "click",
+    "cookiecutter",
+    "pyyaml",
+    "pyserial",
+    "edge-tts",
 ]
 dynamic = ["entry-points"]
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
         "pandas",
         "click",           # for CLI support
         "cookiecutter",    # for template-based scaffolding
+        "pyyaml",          # for YAML configuration parsing
+        "pyserial",        # for serial port communication
+        "edge-tts",        # for text-to-speech support
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- include click, cookiecutter, pyyaml, pyserial and edge-tts in `pyproject.toml`
- update `setup.py` to match

## Testing
- `python -m compileall -q psyflow`
- `psyflow-init --help` *(fails: ModuleNotFoundError: No module named 'psychopy')*
- `python psyflow/cli.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6842c168988c83249eed3801750379ba