### PR TITLE
Improve docs accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ scaffolds a new project using the bundled cookiecutter template.
 Comprehensive documentation and tutorials are available on the
 [GitHub&nbsp;Pages site](https://taskbeacon.github.io/psyflow/).
 
+### Building the documentation
+
+To generate the HTML docs locally:
+
+```bash
+pip install -r docs/requirements.txt
+sphinx-build -b html docs docs/_build/html
+```
+
+Open `docs/_build/html/index.html` in a browser to view them.
+
 ## Publishing to PyPI
 
 Releases are automated with GitHub Actions. Any push to the `main` branch

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -27,7 +27,7 @@ pip install psychopy
 You can install psyflow directly from PyPI:
 
 ```bash
-pip install psyflow==0.1.0
+pip install psyflow==0.1.1
 ```
 
 Or if you prefer to work with the source code:


### PR DESCRIPTION
## Summary
- update installation version in tutorial
- add instructions for building documentation

## Testing
- `sphinx-build -b html docs docs/_build/html` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685fd745c8cc832499eb766dab8e2976